### PR TITLE
refactor: 쿼리 변경 및 제약 조건 추가 

### DIFF
--- a/src/main/java/project/atch/domain/room/entity/Room.java
+++ b/src/main/java/project/atch/domain/room/entity/Room.java
@@ -12,6 +12,9 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @Entity
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"fromId", "toId"})
+})
 public class Room extends BaseEntity {
 
     @Id
@@ -19,17 +22,20 @@ public class Room extends BaseEntity {
     @Column(name = "room_id")
     private Long id;
 
-    /**
-     * fromId와 toId에 unique 제약조건
-     */
     private Long fromId;
 
     private Long toId;
 
     @Builder
     public Room(Long fromId, Long toId){
-        this.fromId = fromId;
-        this.toId = toId;
+        // 항상 fromId < toId로 설정
+        if (fromId > toId) {
+            this.fromId = toId;
+            this.toId = fromId;
+        } else {
+            this.fromId = fromId;
+            this.toId = toId;
+        }
     }
 
 }

--- a/src/main/java/project/atch/domain/room/entity/Room.java
+++ b/src/main/java/project/atch/domain/room/entity/Room.java
@@ -1,6 +1,7 @@
 package project.atch.domain.room.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,8 +23,12 @@ public class Room extends BaseEntity {
     @Column(name = "room_id")
     private Long id;
 
+    @NotNull
+    @Column(nullable = false)
     private Long fromId;
 
+    @NotNull
+    @Column(nullable = false)
     private Long toId;
 
     @Builder

--- a/src/main/java/project/atch/domain/user/dto/UserDetailDto.java
+++ b/src/main/java/project/atch/domain/user/dto/UserDetailDto.java
@@ -5,9 +5,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.atch.domain.user.entity.Character;
+import project.atch.domain.user.entity.Item;
 import project.atch.domain.user.entity.User;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Getter
@@ -29,7 +31,7 @@ public class UserDetailDto {
     // item
     private List<ItemDetail> items;
 
-    public UserDetailDto(User user, Character character, List<ItemDetail> items){
+    public UserDetailDto(User user, Character character, Item item1, Item item2, Item item3){
         this.userId = user.getId();
         this.nickname = user.getNickname();
         this.hashTag = user.getHashTag();
@@ -40,8 +42,11 @@ public class UserDetailDto {
         slots.add(new SlotDetail(character.getX1(), character.getY1()));
         slots.add(new SlotDetail(character.getX2(), character.getY2()));
         slots.add(new SlotDetail(character.getX3(), character.getY3()));
-        this.items = items;
+        this.items = Arrays.asList(
+                new ItemDetail(item1 != null ? item1.getId() : null, item1 != null ? item1.getImage() : null),
+                new ItemDetail(item2 != null ? item2.getId() : null, item2 != null ? item2.getImage() : null),
+                new ItemDetail(item3 != null ? item3.getId() : null, item3 != null ? item3.getImage() : null)
+        );
     }
-
 
 }

--- a/src/main/java/project/atch/domain/user/entity/User.java
+++ b/src/main/java/project/atch/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package project.atch.domain.user.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,10 +10,13 @@ import project.atch.global.entity.BaseEntity;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
-// unique 제약 조건; oAuthProvider + email, nickname
 @Entity
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"email", "oAuthProvider"}),
+        @UniqueConstraint(columnNames = {"nickname"})
+})
 public class User extends BaseEntity {
 
     @Id
@@ -20,7 +24,12 @@ public class User extends BaseEntity {
     @Column(name = "user_id")
     private Long id;
 
+    @NotNull
+    @Column(nullable = false)
     private String email;
+
+    @NotNull
+    @Column(nullable = false)
     private String nickname;
     private String hashTag;
 
@@ -29,8 +38,9 @@ public class User extends BaseEntity {
     private Double longitude; // 경도
 
 
+    @NotNull
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "char(5)")
+    @Column(columnDefinition = "char(5)", nullable = false)
     private OAuthProvider oAuthProvider;
 
     @Enumerated(EnumType.STRING)
@@ -64,13 +74,6 @@ public class User extends BaseEntity {
 
     public void updateNickname(String nickname){
         this.nickname = nickname;
-    }
-    public boolean isInHongdae(){
-        // TODO 임의로 위도 경도 지정. 기획 측에 문의해봐야함.
-        if (37.546856 <= latitude && latitude <= 37.566418 && 126.907221 <= longitude && longitude <= 126.933994){
-            return true;
-        }
-        return false;
     }
 
     public void updateLocation(double latitude, double longitude){

--- a/src/main/java/project/atch/domain/user/repository/UserRepository.java
+++ b/src/main/java/project/atch/domain/user/repository/UserRepository.java
@@ -1,6 +1,9 @@
 package project.atch.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import project.atch.domain.user.dto.UserDetailDto;
 import project.atch.domain.user.entity.User;
 
 import java.util.List;
@@ -9,5 +12,17 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long id);
     Optional<User> findByEmail(String email);
-    List<User> findAllByLocationPermissionTrue();
+
+    @Query("SELECT new project.atch.domain.user.dto.UserDetailDto(u, u.character, i1, i2, i3) " +
+            "FROM User u " +
+            "LEFT JOIN Item i1 ON u.itemId1 = i1.id " +
+            "LEFT JOIN Item i2 ON u.itemId2 = i2.id " +
+            "LEFT JOIN Item i3 ON u.itemId3 = i3.id " +
+            "WHERE u.locationPermission = true " +
+            "AND u.latitude BETWEEN :latMin AND :latMax " +
+            "AND u.longitude BETWEEN :lonMin AND :lonMax")
+    List<UserDetailDto> findUsersWithItems(@Param("latMin") double latMin,
+                                           @Param("latMax") double latMax,
+                                           @Param("lonMin") double lonMin,
+                                           @Param("lonMax") double lonMax);
 }

--- a/src/main/java/project/atch/domain/user/service/HomeService.java
+++ b/src/main/java/project/atch/domain/user/service/HomeService.java
@@ -23,38 +23,16 @@ import java.util.stream.Collectors;
 public class HomeService {
 
     private final UserRepository userRepository;
-    private final ItemRepository itemRepository;
 
     @Transactional(readOnly = true)
     public List<UserDetailDto> getUsersDetail() {
-        List<User> users = userRepository.findAllByLocationPermissionTrue();
-        return users.stream()
-                .filter(User::isInHongdae)
-                .map(this::mapToUserDetailDto)
-                .collect(Collectors.toList());
-    }
 
-    private UserDetailDto mapToUserDetailDto(User user) {
-        List<ItemDetail> items = getItemDetails(user);
-        return new UserDetailDto(user, user.getCharacter(), items);
-    }
+        double latMin = 37.546856;
+        double latMax = 37.566418;
+        double lonMin = 126.907221;
+        double lonMax = 126.933994;
 
-    private List<ItemDetail> getItemDetails(User user) {
-        Long[] itemIds = {user.getItemId1(), user.getItemId2(), user.getItemId3()};
-
-        return Arrays.stream(itemIds)
-                .map(this::findItemDetailById)
-                .collect(Collectors.toList());
-    }
-
-    private ItemDetail findItemDetailById(Long itemId) {
-        if (itemId != null) {
-            Optional<Item> item = itemRepository.findById(itemId);
-            if (item.isPresent()) {
-                return new ItemDetail(item.get().getId(), item.get().getImage());
-            }
-        }
-        return new ItemDetail(null, null);
+        return userRepository.findUsersWithItems(latMin, latMax, lonMin, lonMax);
     }
 
     @Transactional

--- a/src/main/java/project/atch/global/entity/BaseEntity.java
+++ b/src/main/java/project/atch/global/entity/BaseEntity.java
@@ -22,9 +22,4 @@ public class BaseEntity {
     @LastModifiedDate
     private LocalDateTime modifiedAt;
 
-    private Boolean isDeleted = false;
-
-    public void delete() {
-        this.isDeleted = true;
-    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,13 +18,13 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
       ddl-auto: none
-#    show-sql: true
+    show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
         database-platform: org.hibernate.dialect.MySQLDialect
         default_batch_fetch_size: 100
-#        format_sql: true
+        format_sql: true
 
 oauth:
   kakao:
@@ -45,7 +45,7 @@ token:
 
 logging:
   level:
-    root: DEBUG #DEBUG
+    root: INFO #DEBUG
 #    org.hibernate.SQL: DEBUG
 #    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
 #    org.springframework: DEBUG


### PR DESCRIPTION
# PR

## PR 요약
- 두 사용자가 포함된 방을 효율적으로 관리
채팅방 테이블의 유저 아이디 컬럼들을 정렬한 후 저장하는 방식으로 바꾸어 중복 문제를 확인하기 쉽게 하였습니다. 
채팅방 테이블의 유저 아이디들에 복합 유니크 제약 조건을 걸었고, 이에 따라 동시 요청에도 방이 중복 생성되지 않도록 하였습니다.

- 조인을 사용하여 사용자와 아이템 데이터를 한 번에 가져오도록 하여 성능 향상
여러 사용자들과 각 아이템들을 조회하는 메서드에서도 여러 아이템을 중복 조회하지 않도록 조인으로 방식을 수정하였습니다.

## 변경된 점
changes

## 이슈 번호
resolved #13 
