### PR TITLE
feat: 회원 탈퇴/ 차단 로직 구현

### DIFF
--- a/src/main/java/project/atch/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/project/atch/domain/chat/repository/ChatRepository.java
@@ -16,4 +16,5 @@ public interface ChatRepository extends ReactiveMongoRepository<Chat, String>, C
     @Query("{ 'roomId': ?0, 'fromId': { $ne: ?1 } }")
     Flux<Chat> findAllByRoomIdAndFromIdNot(Long roomId, Long fromId);
 
+    Flux<Chat> findTopByRoomIdOrderByCreatedAtDesc(Long roomId);
 }

--- a/src/main/java/project/atch/domain/chat/repository/ChatRepositoryCustom.java
+++ b/src/main/java/project/atch/domain/chat/repository/ChatRepositoryCustom.java
@@ -3,6 +3,8 @@ package project.atch.domain.chat.repository;
 import project.atch.domain.chat.entity.Chat;
 import reactor.core.publisher.Flux;
 
+import java.util.List;
+
 public interface ChatRepositoryCustom {
-    Flux<Chat> findOldestMessagesFromAllRooms(int limit, long lastId);
+    Flux<Chat> findOldestMessagesFromAllRooms(int limit, long lastId, List<Long> excludedRoomIds);
 }

--- a/src/main/java/project/atch/domain/room/controller/RoomController.java
+++ b/src/main/java/project/atch/domain/room/controller/RoomController.java
@@ -12,13 +12,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import project.atch.domain.chat.dto.PreviewMessageDto;
+import project.atch.domain.room.dto.MyMessagePreviewDto;
+import project.atch.domain.room.dto.OtherMessagePreviewDto;
 import project.atch.domain.room.dto.RoomFormDto;
 import project.atch.domain.room.service.RoomService;
-import project.atch.global.exception.CustomException;
-import project.atch.global.exception.ErrorCode;
 import project.atch.global.security.CustomUserDetails;
 import project.atch.global.stomp.RoomUserCountManager;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -49,6 +49,18 @@ public class RoomController {
         return roomService.createRoom(userDetails.getUserId(), form.userId());
     }
 
+    @Operation(summary = "내 채팅",
+            description = "자신이 속한 채팅방과 상대방의 프로필을 확인합니다.")
+    @Parameters({
+            @Parameter(name = "limit", description = "한 페이지 당 몇 개의 데이터를 가져올 지"),
+            @Parameter(name = "lastId", description = "마지막 채팅방 아이디")
+    })
+    @GetMapping("/active")
+    public Flux<MyMessagePreviewDto> findAllMyRooms(@AuthenticationPrincipal CustomUserDetails userDetails){
+        return roomService.getAllMyRooms(userDetails.getUserId());
+    }
+
+
     @Operation(summary = "전체 채팅방 + 미리보기 조회",
             description = "전체 채팅방과 각 채팅방의 첫 번째 채팅 메세지를 확인합니다.\n"
                     +"커서 기반 페이지네이션으로 작동합니다.")
@@ -57,7 +69,7 @@ public class RoomController {
             @Parameter(name = "lastId", description = "마지막 채팅방 아이디")
     })
     @GetMapping
-    public Mono<ResponseEntity<List<PreviewMessageDto>>> findAllRooms(@RequestParam(defaultValue = "10") int limit, @RequestParam(defaultValue = "-1") long lastId){
+    public Mono<ResponseEntity<List<OtherMessagePreviewDto>>> findAllRooms(@RequestParam(defaultValue = "10") int limit, @RequestParam(defaultValue = "-1") long lastId){
         return roomService.getAllRoomsWithPreviews(limit, lastId)
                 .collectList()
                 .map(ResponseEntity::ok);

--- a/src/main/java/project/atch/domain/room/controller/RoomController.java
+++ b/src/main/java/project/atch/domain/room/controller/RoomController.java
@@ -61,7 +61,6 @@ public class RoomController {
     }
 
 
-    // TODO 차단한 상대방 제외
     @Operation(summary = "전체 채팅방 + 미리보기 조회",
             description = "전체 채팅방과 각 채팅방의 첫 번째 채팅 메세지를 확인합니다.\n"
                     +"커서 기반 페이지네이션으로 작동합니다.")

--- a/src/main/java/project/atch/domain/room/controller/RoomController.java
+++ b/src/main/java/project/atch/domain/room/controller/RoomController.java
@@ -61,6 +61,7 @@ public class RoomController {
     }
 
 
+    // TODO 차단한 상대방 제외
     @Operation(summary = "전체 채팅방 + 미리보기 조회",
             description = "전체 채팅방과 각 채팅방의 첫 번째 채팅 메세지를 확인합니다.\n"
                     +"커서 기반 페이지네이션으로 작동합니다.")
@@ -69,8 +70,10 @@ public class RoomController {
             @Parameter(name = "lastId", description = "마지막 채팅방 아이디")
     })
     @GetMapping
-    public Mono<ResponseEntity<List<OtherMessagePreviewDto>>> findAllRooms(@RequestParam(defaultValue = "10") int limit, @RequestParam(defaultValue = "-1") long lastId){
-        return roomService.getAllRoomsWithPreviews(limit, lastId)
+    public Mono<ResponseEntity<List<OtherMessagePreviewDto>>> findAllRooms(@RequestParam(defaultValue = "10") int limit,
+                                                                           @RequestParam(defaultValue = "-1") long lastId,
+                                                                           @AuthenticationPrincipal CustomUserDetails userDetails){
+        return roomService.getAllRoomsWithPreviews(limit, lastId, userDetails.getUserId())
                 .collectList()
                 .map(ResponseEntity::ok);
     }

--- a/src/main/java/project/atch/domain/room/dto/MyMessagePreviewDto.java
+++ b/src/main/java/project/atch/domain/room/dto/MyMessagePreviewDto.java
@@ -1,0 +1,28 @@
+package project.atch.domain.room.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import project.atch.domain.chat.entity.Chat;
+import project.atch.domain.user.entity.User;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MyMessagePreviewDto {
+    private Long roomId;
+    private String content;
+    private Long fromId;
+    private String fromNickname;
+    private List<String> hashTag;
+    private String image;
+    private Date createdAt;
+
+    static public MyMessagePreviewDto of(Chat chat, User user){
+        return new MyMessagePreviewDto(chat.getRoomId(), chat.getContent(), chat.getFromId(), user.getNickname(),
+                Arrays.asList(user.getHashTag().split(",")), user.getCharacter().getImage(), chat.getCreatedAt());
+    }
+
+}

--- a/src/main/java/project/atch/domain/room/dto/OtherMessagePreviewDto.java
+++ b/src/main/java/project/atch/domain/room/dto/OtherMessagePreviewDto.java
@@ -1,4 +1,4 @@
-package project.atch.domain.chat.dto;
+package project.atch.domain.room.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,7 +9,7 @@ import java.util.Date;
 
 @Getter
 @AllArgsConstructor
-public class PreviewMessageDto {
+public class OtherMessagePreviewDto {
     private Long roomId;
     private String content;
     private Long fromId;
@@ -17,8 +17,8 @@ public class PreviewMessageDto {
     private Date createdAt;
     private Boolean read;
 
-    static public PreviewMessageDto of(Chat chat, String nickname) {
-        return new PreviewMessageDto(chat.getRoomId(), chat.getContent(), chat.getFromId(),
+    static public OtherMessagePreviewDto of(Chat chat, String nickname) {
+        return new OtherMessagePreviewDto(chat.getRoomId(), chat.getContent(), chat.getFromId(),
                 nickname, chat.getCreatedAt(), chat.isRead());
     }
 

--- a/src/main/java/project/atch/domain/room/repository/RoomRepository.java
+++ b/src/main/java/project/atch/domain/room/repository/RoomRepository.java
@@ -1,6 +1,8 @@
 package project.atch.domain.room.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import project.atch.domain.room.entity.Room;
 
 import java.util.List;
@@ -9,4 +11,12 @@ import java.util.Optional;
 public interface RoomRepository extends JpaRepository<Room, Long> {
     Optional<Room> findByFromIdAndToId(Long fromId, Long toId);
     List<Room> findByFromIdOrToId(Long fromId, Long toId);
+
+    @Query("SELECT r FROM Room r WHERE (r.fromId = :userId OR r.toId = :userId) " +
+            "AND r.fromId NOT IN :blockedIds AND r.toId NOT IN :blockedIds")
+    List<Room> findFilteredRooms(@Param("userId") Long userId, @Param("blockedIds") List<Long> blockedIds);
+
+    @Query("SELECT DISTINCT r.id FROM Room r WHERE r.fromId IN :ids OR r.toId IN :ids")
+    List<Long> findRoomIdsByUserIds(@Param("ids") List<Long> ids);
+
 }

--- a/src/main/java/project/atch/domain/room/repository/RoomRepository.java
+++ b/src/main/java/project/atch/domain/room/repository/RoomRepository.java
@@ -3,8 +3,10 @@ package project.atch.domain.room.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import project.atch.domain.room.entity.Room;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
     Optional<Room> findByFromIdAndToId(Long fromId, Long toId);
+    List<Room> findByFromIdOrToId(Long fromId, Long toId);
 }

--- a/src/main/java/project/atch/domain/user/controller/HomeController.java
+++ b/src/main/java/project/atch/domain/user/controller/HomeController.java
@@ -22,11 +22,12 @@ public class HomeController {
 
     private final HomeService homeService;
 
+    // TODO 차단한 상대방 제외
     @Operation(summary = "지도 내 위치하는 모든 사용자 조회",
             description = "현재 홍대 내 위치하는 모든 사용자의 일부 정보를 가져옵니다.")
     @GetMapping("/home")
-    public List<UserDetailDto> getUsersDetail(){
-        return homeService.getUsersDetail();
+    public List<UserDetailDto> getUsersDetail(@AuthenticationPrincipal CustomUserDetails userDetails){
+        return homeService.getUsersDetail(userDetails.getUserId());
     }
 
     @Operation(summary = "사용자의 위치 업데이트",

--- a/src/main/java/project/atch/domain/user/controller/HomeController.java
+++ b/src/main/java/project/atch/domain/user/controller/HomeController.java
@@ -22,7 +22,6 @@ public class HomeController {
 
     private final HomeService homeService;
 
-    // TODO 차단한 상대방 제외
     @Operation(summary = "지도 내 위치하는 모든 사용자 조회",
             description = "현재 홍대 내 위치하는 모든 사용자의 일부 정보를 가져옵니다.")
     @GetMapping("/home")

--- a/src/main/java/project/atch/domain/user/controller/UserController.java
+++ b/src/main/java/project/atch/domain/user/controller/UserController.java
@@ -109,4 +109,12 @@ public class UserController {
         return new ResponseEntity(HttpStatus.NO_CONTENT);
     }
 
+    @Operation(summary = "특정 사용자를 차단")
+    @PostMapping("/block")
+    public ResponseEntity blockUser(@RequestBody RequestBlockDto dto,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
+        userService.blockUser(userDetails.getUserId(), dto.getUserId());
+        return new ResponseEntity(HttpStatus.CREATED);
+    }
+
 }

--- a/src/main/java/project/atch/domain/user/controller/UserController.java
+++ b/src/main/java/project/atch/domain/user/controller/UserController.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import project.atch.domain.user.dto.*;
@@ -22,6 +24,7 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+
     @Operation(summary = "모든 캐릭터 조회",
             description = "사용자가 캐릭터를 선택할 수 있도록 모든 캐릭터를 조회합니다.")
     @GetMapping("/character")
@@ -97,6 +100,13 @@ public class UserController {
     public void updateItem(@RequestBody ItemDto.Req dto,
                            @AuthenticationPrincipal CustomUserDetails userDetails){
         userService.updateItems(userDetails.getUserId(), dto.itemId1(), dto.itemId2(), dto.itemId3());
+    }
+
+    @Operation(summary = "사용자의 회원 탈퇴")
+    @DeleteMapping()
+    public ResponseEntity withdrawal(@AuthenticationPrincipal CustomUserDetails userDetails){
+        userService.withdrawal(userDetails.getUserId());
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
     }
 
 }

--- a/src/main/java/project/atch/domain/user/dto/RequestBlockDto.java
+++ b/src/main/java/project/atch/domain/user/dto/RequestBlockDto.java
@@ -1,0 +1,14 @@
+package project.atch.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class RequestBlockDto {
+
+    private final long userId;
+
+    public RequestBlockDto(@JsonProperty("userId") long userId){
+        this.userId = userId;
+    }
+}

--- a/src/main/java/project/atch/domain/user/entity/Block.java
+++ b/src/main/java/project/atch/domain/user/entity/Block.java
@@ -1,0 +1,31 @@
+package project.atch.domain.user.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import project.atch.global.entity.BaseEntity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"blockerId", "blockedId"})
+})
+public class Block extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "block_id")
+    private Long id;
+
+    @NotNull
+    @Column(nullable = false)
+    private Long blockerId; // 차단한 사용자 계정
+
+    @NotNull
+    @Column(nullable = false)
+    private Long blockedId; // 차단 당한 사용자 계정
+}

--- a/src/main/java/project/atch/domain/user/entity/Block.java
+++ b/src/main/java/project/atch/domain/user/entity/Block.java
@@ -3,6 +3,7 @@ package project.atch.domain.user.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import project.atch.global.entity.BaseEntity;
@@ -28,4 +29,10 @@ public class Block extends BaseEntity {
     @NotNull
     @Column(nullable = false)
     private Long blockedId; // 차단 당한 사용자 계정
+
+    public Block(Long blockerId, Long blockedId){
+        this.blockerId = blockerId;
+        this.blockedId = blockedId;
+    }
+
 }

--- a/src/main/java/project/atch/domain/user/entity/User.java
+++ b/src/main/java/project/atch/domain/user/entity/User.java
@@ -47,7 +47,7 @@ public class User extends BaseEntity {
     @Column(columnDefinition = "varchar(10)")
     private Role role;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "character_id")
     private Character character;
 

--- a/src/main/java/project/atch/domain/user/repository/BlockRepository.java
+++ b/src/main/java/project/atch/domain/user/repository/BlockRepository.java
@@ -1,0 +1,7 @@
+package project.atch.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import project.atch.domain.user.entity.Block;
+
+public interface BlockRepository extends JpaRepository<Block, Long> {
+}

--- a/src/main/java/project/atch/domain/user/repository/BlockRepository.java
+++ b/src/main/java/project/atch/domain/user/repository/BlockRepository.java
@@ -1,7 +1,13 @@
 package project.atch.domain.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import project.atch.domain.user.entity.Block;
 
+import java.util.List;
+
 public interface BlockRepository extends JpaRepository<Block, Long> {
+    @Query("SELECT b.blockedId FROM Block b WHERE b.blockerId = :blockerId")
+    List<Long> findBlockedIdsByBlockerId(@Param("blockerId") Long blockerId);
 }

--- a/src/main/java/project/atch/domain/user/repository/UserItemRepository.java
+++ b/src/main/java/project/atch/domain/user/repository/UserItemRepository.java
@@ -21,6 +21,8 @@ public interface UserItemRepository extends JpaRepository<UserItem, UserItemId> 
 
     boolean existsByUserAndItem(User user, Item item);
 
+    void deleteByUserId(Long userId);
+
     @Query("SELECT ui FROM UserItem ui WHERE ui.user.id = :userId AND ui.item.id = :itemId")
     Optional<UserItem> findByUserIdAndItemId(@Param("userId") Long userId, @Param("itemId") Long itemId);
 

--- a/src/main/java/project/atch/domain/user/service/HomeService.java
+++ b/src/main/java/project/atch/domain/user/service/HomeService.java
@@ -6,9 +6,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.atch.domain.user.dto.UserDetailDto;
 import project.atch.domain.user.entity.User;
+import project.atch.domain.user.repository.BlockRepository;
 import project.atch.domain.user.repository.UserRepository;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -16,16 +18,25 @@ import java.util.List;
 public class HomeService {
 
     private final UserRepository userRepository;
+    private final BlockRepository blockRepository;
 
     @Transactional(readOnly = true)
-    public List<UserDetailDto> getUsersDetail() {
+    public List<UserDetailDto> getUsersDetail(long userId) {
+
+        List<Long> blockedId = blockRepository.findBlockedIdsByBlockerId(userId);
 
         double latMin = 37.548264;
         double latMax = 37.564515;
         double lonMin = 126.914907;
         double lonMax = 126.928451;
 
-        return userRepository.findUsersWithItems(latMin, latMax, lonMin, lonMax);
+        // 사용자 목록 조회
+        List<UserDetailDto> users = userRepository.findUsersWithItems(latMin, latMax, lonMin, lonMax);
+
+        // blockedId에 포함되지 않은 사용자만 필터링
+        return users.stream()
+                .filter(user -> !blockedId.contains(user.getUserId())) // blockedId에 없는 사용자만 필터링
+                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/main/java/project/atch/domain/user/service/UserService.java
+++ b/src/main/java/project/atch/domain/user/service/UserService.java
@@ -96,5 +96,8 @@ public class UserService {
     public void blockUser(Long blockerId, long blockedId) {
         Block block = new Block(blockerId, blockedId);
         blockRepository.save(block);
+
+        Block reverseBlock = new Block(blockedId, blockerId);
+        blockRepository.save(reverseBlock);
     }
 }

--- a/src/main/java/project/atch/domain/user/service/UserService.java
+++ b/src/main/java/project/atch/domain/user/service/UserService.java
@@ -6,12 +6,10 @@ import org.springframework.transaction.annotation.Transactional;
 import project.atch.domain.user.dto.ItemDetail;
 import project.atch.domain.user.dto.ItemDto;
 import project.atch.domain.user.dto.ResponseCharacterDto;
+import project.atch.domain.user.entity.Block;
 import project.atch.domain.user.entity.Character;
 import project.atch.domain.user.entity.User;
-import project.atch.domain.user.repository.CharacterRepository;
-import project.atch.domain.user.repository.ItemRepository;
-import project.atch.domain.user.repository.UserItemRepository;
-import project.atch.domain.user.repository.UserRepository;
+import project.atch.domain.user.repository.*;
 import project.atch.global.exception.CustomException;
 import project.atch.global.exception.ErrorCode;
 
@@ -26,6 +24,7 @@ public class UserService {
     private final CharacterRepository characterRepository;
     private final UserItemRepository userItemRepository;
     private final ItemRepository itemRepository;
+    private final BlockRepository blockRepository;
 
     @Transactional(readOnly = true)
     public List<ResponseCharacterDto> findAllCharacters(){
@@ -91,5 +90,11 @@ public class UserService {
     public void withdrawal(Long userId) {
         userItemRepository.deleteByUserId(userId);
         userRepository.deleteById(userId);
+    }
+
+    @Transactional
+    public void blockUser(Long blockerId, long blockedId) {
+        Block block = new Block(blockerId, blockedId);
+        blockRepository.save(block);
     }
 }

--- a/src/main/java/project/atch/domain/user/service/UserService.java
+++ b/src/main/java/project/atch/domain/user/service/UserService.java
@@ -86,4 +86,10 @@ public class UserService {
             return null; // 만족하지 않는 경우 null을 반환
         }
     }
+
+    @Transactional
+    public void withdrawal(Long userId) {
+        userItemRepository.deleteByUserId(userId);
+        userRepository.deleteById(userId);
+    }
 }


### PR DESCRIPTION
# PR

## PR 요약
- 회원 탈퇴/ 차단 로직을 구현하였습니다.
  - A 사용자가 B 사용자를 차단 시, A 사용자는 B 사용자를 홈화면/ 전체채팅/ 내채팅에서 확인할 수 없고, 반대의 경우에도 마찬가지입니다.
- 내 채팅방을 조회하는 API를 구현하였습니다.

## 변경된 점
changes

## 이슈 번호
resolved #18 , #20 
